### PR TITLE
Created Polish translation

### DIFF
--- a/src/main/resources/assets/modnametooltip/lang/pl_pl.json
+++ b/src/main/resources/assets/modnametooltip/lang/pl_pl.json
@@ -1,0 +1,4 @@
+{
+    "config.modnametooltip.formatting.modNameFormat": "Format nazwy moda",
+    "config.modnametooltip.formatting.modNameFormat.comment": "Określa, jak powinna być sformatowana nazwa moda w tooltipach. Pozostaw puste, aby wyłączyć."
+}


### PR DESCRIPTION
As the title says, in this commit I added Polish translation.

I also tried to backport this translation to the old language files format, used by Mod Name Tooltip for Minecraft 1.12, but since branch `1.12` contains changes also for version 1.13, it is no longer possible, I think.